### PR TITLE
Use source-original to prevent spurious naming errors

### DIFF
--- a/flycheck-kotlin.el
+++ b/flycheck-kotlin.el
@@ -5,7 +5,7 @@
 ;; Author: Elric Milon <whirm_REMOVETHIS__@gmx.com>
 ;; Created: 20 January 2017
 ;; Version: 0.1
-;; Package-Requires: ((flycheck "0.18"))
+;; Package-Requires: ((flycheck "0.20"))
 
 ;;; Commentary:
 
@@ -41,10 +41,11 @@
 (flycheck-define-checker kotlin-ktlint
   "A Kotlin syntax and style checker using the ktlint utility.
 See URL `https://github.com/shyiko/ktlint'."
-  :command ("ktlint" source-inplace)
+  :command ("ktlint" source-original)
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": " (message) line-end))
-  :modes kotlin-mode)
+  :modes kotlin-mode
+  :predicate flycheck-buffer-saved-p)
 
 
 ;;;###autoload


### PR DESCRIPTION
When using `source-inplace` the file Foo.kt to be checked becomes flycheck_Foo.kt, and ktlint may give an error:

```
class Foo should be declared in a file named Foo.kt (cannot be auto-corrected)
```

This is a desirable error so rather than disabling it we check the original file (despite Flycheck's admonition not to use `source-original` "unless absolutely necessary").

`flycheck-buffer-saved-p` was added in https://github.com/flycheck/flycheck/commit/ec7b24d1dfb0e1fcd224b8801fc4eeb13fb7198f before the 0.20 release.